### PR TITLE
[공유하기] userAgent 추가 및 앱 열기 브릿지함수 추가 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/goormthoonuniv/sodong/JavaScriptInterface.kt
+++ b/app/src/main/java/com/goormthoonuniv/sodong/JavaScriptInterface.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
+import android.util.Log
 import android.webkit.JavascriptInterface
 import android.widget.Toast
 import androidx.core.content.ContextCompat.startActivity
@@ -33,6 +34,7 @@ class JavaScriptInterface(private val mContext: Context) {
      */
     @JavascriptInterface
     fun shareInsta(uriStr: String) {
+        Log.d("###shareInsta", uriStr)
         val shareIntent = Intent(Intent.ACTION_SEND)
         val bundle = Bundle()
 
@@ -75,6 +77,7 @@ class JavaScriptInterface(private val mContext: Context) {
      */
     @JavascriptInterface
     fun downloadImage(imgUrl: String): String {
+        Log.d("###downloadImage", imgUrl)
         try {
             return downloadImageToExternalStorage(imgUrl)
         } catch (e: IOException) {
@@ -127,5 +130,29 @@ class JavaScriptInterface(private val mContext: Context) {
         return uri.toString()
     }
 
+    /**
+     * openApp
+     * @param packageName - 앱 패키지 명 (com.kakao.talk - 카카오톡, com.towneers.www - 당근마켓, com.kakao.yellowid - 카카오톡 채널)
+     */
+    @JavascriptInterface
+    fun openApp(packageName: String) {
+        Log.d("###openApp", packageName)
+
+        val bundle = Bundle()
+        try {
+            val intent: Intent = mContext.packageManager.getLaunchIntentForPackage(packageName)
+                ?: throw Exception("Intent is null")
+
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(mContext, intent, bundle)
+        } catch (exception: Exception) {
+            exception.printStackTrace()
+            Toast.makeText(mContext, "앱을 설치해 주세요", Toast.LENGTH_LONG).show()
+
+            val url = "market://details?id=$packageName"
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            startActivity(mContext, intent, bundle)
+        }
+    }
 
 }

--- a/app/src/main/java/com/goormthoonuniv/sodong/MainActivity.kt
+++ b/app/src/main/java/com/goormthoonuniv/sodong/MainActivity.kt
@@ -36,6 +36,9 @@ class MainActivity: BaseActivity<ActivityMainBinding>(ActivityMainBinding::infla
         webView.webViewClient = webViewClient
         webView.webChromeClient = webChromeClient
 
+        // Android 구분을 위한 User Agent 추가
+        webView.settings.userAgentString = webView.settings.userAgentString + " sodong_aos"
+
         // TODO: 크롬 인스펙터 확인
         WebView.setWebContentsDebuggingEnabled(true)
     }


### PR DESCRIPTION
## 🪄 Issue Number
- close #6 

## 🏆 Details
- [x] 웹에서 안드로이드 앱 구분을 위해 userAgent에 'sodong_aos' 추가
- [x] 로컬 테스트를 위해 http 허용 
- [x] SNS 공유하기를 위한 `openApp()` 브릿지함수 추가 

## ✅ Need Review
- 해당 앱으로 랜딩하는 브릿지함수 `openApp()` 호출 시, 앱의 패키지 이름을 보내주어야 합니다.
<img width="943" alt="image" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_27_FE_2/assets/87323603/eafd71d1-a7b4-4e4f-9057-2aa7b4b88485">

## 📸 Screenshot
https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_27_FE_2/assets/87323603/76d52b72-0c08-46ac-81c4-ceebb968a06f

## 📚 Reference
